### PR TITLE
Remove duplicate domain from Tiktok service

### DIFF
--- a/dist/vpn_services.json
+++ b/dist/vpn_services.json
@@ -144,7 +144,6 @@
       "bytecdn.cn",
       "byted.org",
       "bytedanceapi.com",
-      "byteoversea.com",
       "byteoversea.net",
       "ibytedtos.com",
       "isnssdk.com",


### PR DESCRIPTION
Remove duplicate domain `byteoversea.com` from Tiktok service.