### PR TITLE
Fix gvt1.com in vpn services

### DIFF
--- a/dist/vpn_services.json
+++ b/dist/vpn_services.json
@@ -418,7 +418,6 @@
       "VIDEO"
     ],
     "domains": [
-      "gvt1.com",
       "youtu.be",
       "youtube-nocookie.com",
       "youtube.com",
@@ -901,6 +900,7 @@
       "googleweblight.in",
       "googlezip.net",
       "gstatic.com",
+      "gvt1.com",
       "gvt2.com",
       "gvt3.com",
       "withgoogle.com"


### PR DESCRIPTION
according to 
https://github.com/AdguardTeam/companiesdb/pull/77
https://github.com/AdguardTeam/companiesdb/issues/68
`gvt1.com` is used by Google