### PR TITLE
Add company FarLight Pte Ltd.

### DIFF
--- a/source/companies.json
+++ b/source/companies.json
@@ -66,6 +66,11 @@
             "websiteUrl": "https://www.facebook.com/",
             "description": "Facebook is an online social network accessible to anyone with an active email address. People use Facebook to keep up with friends, upload photos, share links and videos, and learn more about the people they meet."
         },
+        "farlight": {
+            "name": "Farlight Pte Ltd.",
+            "websiteUrl": "https://farlightgames.com/",
+            "description": "Farlight Games is a publishing company and the global publishing brand of Lilith Games."
+        },
         "foxtel": {
             "name": "Foxtel",
             "websiteUrl": "https://www.foxtel.com.au/",

--- a/source/trackers.json
+++ b/source/trackers.json
@@ -212,6 +212,12 @@
             "url": "https://developers.facebook.com/plugins",
             "companyId": "meta"
         },
+        "farlight_pte_ltd": {
+            "name": "Farlight Pte Ltd.",
+            "categoryId": 8,
+            "url": "https://farlightgames.com/",
+            "companyId": "farlight"
+        },
         "firebase": {
             "name": "Firebase",
             "categoryId": 101,
@@ -866,6 +872,7 @@
         "element.io": "element",
         "riot.im": "element",
         "graph.facebook.com": "facebook_audience",
+        "farlightgames.com": "farlight_pte_ltd",
         "app-measurement.com": "firebase",
         "fcm.googleapis.com": "firebase",
         "firebaseappcheck.googleapis.com": "firebase",


### PR DESCRIPTION
FarLight Games is the publisher for Lilith Games, publishing many major titles on current mobile app stores.