### PR TITLE
Add Vungle

### DIFF
--- a/source/companies.json
+++ b/source/companies.json
@@ -41,6 +41,11 @@
             "websiteUrl": "https://bitwarden.com/",
             "description": "Bitwarden is an integrated open source password management solution for individuals, teams, and business organizations."
         },
+        "blackstone": {
+            "name": "Blackstone, Inc.",
+            "websiteUrl": "https://www.blackstone.com/",
+            "description": "Blackstone Group is a private equity firm that invests in buyouts, debt, mergers and acquisitions, mezzanine, and growth capital."
+        },
         "branch_metrics_inc": {
             "name": "Branch Metrics",
             "websiteUrl": "https://branch.io/",

--- a/source/trackers.json
+++ b/source/trackers.json
@@ -1541,6 +1541,7 @@
         "vscode-unpkg.net": "vscode",
         "v0cdn.net": "vscode",
         "vscode-cdn.net": "vscode",
+        "liftoff.io": "vungle",
         "vungle.com": "vungle",
         "whatsapp.net": "whatsapp",
         "whatsapp.com": "whatsapp",

--- a/source/trackers.json
+++ b/source/trackers.json
@@ -728,6 +728,12 @@
             "url": "https://code.visualstudio.com/",
             "companyId": "microsoft"
         },
+        "vungle": {
+            "name": "Vungle",
+            "categoryId": 4,
+            "url": "https://vungle.com/",
+            "companyId": "blackstone"
+        },
         "whatsapp": {
             "name": "WhatsApp",
             "categoryId": 8,
@@ -1535,6 +1541,7 @@
         "vscode-unpkg.net": "vscode",
         "v0cdn.net": "vscode",
         "vscode-cdn.net": "vscode",
+        "vungle.com": "vungle",
         "whatsapp.net": "whatsapp",
         "whatsapp.com": "whatsapp",
         "maps.windows.com": "windows_maps",


### PR DESCRIPTION
> Vungle transforms how people discover and experience apps that delivers the highest value users through engaging video ads.

- Add parent company [Blackstone, Inc.](https://www.blackstone.com/news/press/blackstone-closes-acquisition-of-vungle-a-leading-mobile-performance-marketing-platform/)
- Add tracker company Vungle

    - As a note, Vungle and [Liftoff](https://liftoff.io) have merged, and are both owned by Blackstone, Inc. At this stage there is no unified name for the merger. The [internal name](https://www.forbes.com/sites/johnkoetsier/2021/08/24/liftoff-and-vungle-merge-2-top-ten-mobile-ad-networks-owned-by-private-equity-fund-blackstone-combine-forces/?sh=5d8475203373) is "Liftoff+Vungle".

- Add tracker domain for Vungle which covers all current known subdomains