### PR TITLE
Fix AppNexus parent company

### DIFF
--- a/source/trackers.json
+++ b/source/trackers.json
@@ -56,10 +56,22 @@
             "url": "https://www.akamai.com/",
             "companyId": "akamai"
         },
+        "alenty": {
+            "name": "Alenty",
+            "categoryId": 4,
+            "url": "https://about.ads.microsoft.com/en-us/solutions/xandr/xandr-premium-programmatic-advertising",
+            "companyId": "microsoft"
+        },
         "appcenter": {
             "name": "Microsoft App Center",
             "categoryId": 5,
             "url": "https://appcenter.ms/",
+            "companyId": "microsoft"
+        },
+        "appnexus": {
+            "name": "AppNexus",
+            "categoryId": 4,
+            "url": "https://about.ads.microsoft.com/en-us/solutions/xandr/xandr-premium-programmatic-advertising",
             "companyId": "microsoft"
         },
         "alibaba_cloud": {
@@ -458,6 +470,12 @@
             "url": "https://matrix.org/",
             "companyId": "matrix"
         },
+        "mediaglu": {
+            "name": "MediaGlu",
+            "categoryId": 4,
+            "url": "https://www.mediaglu.com/",
+            "companyId": "microsoft"
+        },
         "medialab": {
             "name": "MediaLab.AI Inc.",
             "categoryId": 8,
@@ -511,6 +529,12 @@
             "categoryId": 5,
             "url": "https://ntp.org/",
             "companyId": "ntppool"
+        },
+        "open_adstream": {
+            "name": "Open Adstream",
+            "categoryId": 4,
+            "url": "https://about.ads.microsoft.com/en-us/solutions/xandr/xandr-premium-programmatic-advertising",
+            "companyId": "microsoft"
         },
         "oppo": {
             "name": "OPPO",


### PR DESCRIPTION
Fixed subsidiaries linked to AppNexus as a result.

- Alenty [acquired](https://www.prnewswire.com/news-releases/appnexus-acquires-leading-advertising-viewability-company-alenty-261851341.html) by AppNexus
- MediaGlu [acquired](https://www.forbes.com/sites/alexkonrad/2014/12/18/appnexus-buys-mediaglu-spends-200-million/#:~:text=AppNexus%20Draws%20Closer%20To%20IPO,For%20A%20Combined%20%24200%20Million) by AppNexus
- Open Adstream [acquired](https://www.prnewswire.com/news-releases/appnexus-completes-open-adstream-acquisition-and-closes-110-million-funding-round-281092902.html) by AppNexus
- AppNexus [acquired](https://www.adexchanger.com/online-advertising/xandr-formerly-appnexus-is-now-formerly-att-after-its-acquisition-by-microsoft/) by Microsoft
- url's for each tracker fixed
- MediaGlu name fixed