### PR TITLE
Fix GitHub, Inc.

### DIFF
--- a/source/trackers.json
+++ b/source/trackers.json
@@ -260,6 +260,12 @@
             "url": "https://foxtel.com.au/",
             "companyId": "foxtel"
         },
+        "github": {
+            "name": "GitHub, Inc.",
+            "categoryId": 2,
+            "url": "https://github.com/",
+            "companyId": "microsoft"
+        },
         "gmail": {
             "name": "Gmail",
             "categoryId": 13,


### PR DESCRIPTION
 - Update GitHub, Inc. trading name based on their [privacy policy](https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement#)
 - Update GitHub, Inc. parent company, due to being [acquired](https://news.microsoft.com/announcement/microsoft-acquires-github/) by Microsoft