### PR TITLE
Fix Mobvista

### DIFF
--- a/source/companies.json
+++ b/source/companies.json
@@ -156,6 +156,11 @@
             "websiteUrl": "https://www.microsoft.com/",
             "description": "Microsoft is an American multinational corporation that develops, manufactures, licenses, supports, and sells a range of software products and services."
         },
+        "mobvista": {
+            "name": "Mobvista",
+            "websiteUrl": "https://www.mobvista.com/",
+            "description": "Mobvista is a technology platform dedicated to driving global business growth in the digital age using big data & AI."
+        },
         "mozilla": {
             "name": "Mozilla Foundation",
             "websiteUrl": "https://www.mozilla.org/",

--- a/source/trackers.json
+++ b/source/trackers.json
@@ -272,6 +272,12 @@
             "url": "https://foxtel.com.au/",
             "companyId": "news_corp"
         },
+        "gameanalytics": {
+            "name": "GameAnalytics",
+            "categoryId": 101,
+            "url": "https://gameanalytics.com/",
+            "companyId": "mobvista"
+        },
         "github": {
             "name": "GitHub, Inc.",
             "categoryId": 2,
@@ -1081,6 +1087,7 @@
         "freeviewaustralia.tv": "freeview",
         "freeview.com.au": "freeview",
         "freeview.com": "freeview",
+        "gameanalytics.com": "gameanalytics",
         "ghcr.io": "github",
         "github.dev": "github",
         "gmail.com": "gmail",


### PR DESCRIPTION
- Add GameAnalytics to source/trackers
- Add GameAnalytics [parent](https://venturebeat.com/business/chinas-ad-tech-firm-mobvista-buys-denmarks-gameanalytics/) company Mobvista to source/companies
- Add tracker for GameAnalytics