### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,12 +11,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18.x
 
       - name: Lint
         run: |
@@ -26,12 +26,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18.x
 
       - name: Run conversion
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   schedule:
     - cron: "0 0 */7 * *" # Every week
+    
+env:
+  NODE_VERSION: 18.x
 
 jobs:
   lint:
@@ -16,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Lint
         run: |
@@ -31,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Run conversion
         run: |


### PR DESCRIPTION
Node 16 has reached [EOL](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) for GH Actions.
This commit updates the Actions to their latest stable release, IAW recommendations.

<details>

<summary>Test lint run</summary>

```
2023-09-25T08:42:55.5317049Z Requested labels: ubuntu-latest
2023-09-25T08:42:55.5317316Z Job defined at: jslawler/companiesdb/.github/workflows/workflow.yml@refs/heads/actions-test
2023-09-25T08:42:55.5317501Z Waiting for a runner to pick up this job...
2023-09-25T08:42:56.6894755Z Job is waiting for a hosted runner to come online.
2023-09-25T08:43:00.1196685Z Job is about to start running on the hosted runner: GitHub Actions 1 (hosted)
2023-09-25T08:43:03.6318230Z Current runner version: '2.309.0'
2023-09-25T08:43:03.6347756Z ##[group]Operating System
2023-09-25T08:43:03.6348242Z Ubuntu
2023-09-25T08:43:03.6348655Z 22.04.3
2023-09-25T08:43:03.6348923Z LTS
2023-09-25T08:43:03.6349160Z ##[endgroup]
2023-09-25T08:43:03.6349476Z ##[group]Runner Image
2023-09-25T08:43:03.6349869Z Image: ubuntu-22.04
2023-09-25T08:43:03.6350140Z Version: 20230917.1.0
2023-09-25T08:43:03.6350647Z Included Software: https://github.com/actions/runner-images/blob/ubuntu22/20230917.1/images/linux/Ubuntu2204-Readme.md
2023-09-25T08:43:03.6351262Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20230917.1
2023-09-25T08:43:03.6351719Z ##[endgroup]
2023-09-25T08:43:03.6352064Z ##[group]Runner Image Provisioner
2023-09-25T08:43:03.6352397Z 2.0.299.1
2023-09-25T08:43:03.6352680Z ##[endgroup]
2023-09-25T08:43:03.6353286Z ##[group]GITHUB_TOKEN Permissions
2023-09-25T08:43:03.6354931Z Contents: read
2023-09-25T08:43:03.6355261Z Metadata: read
2023-09-25T08:43:03.6355757Z Packages: read
2023-09-25T08:43:03.6356210Z ##[endgroup]
2023-09-25T08:43:03.6359878Z Secret source: Actions
2023-09-25T08:43:03.6360363Z Prepare workflow directory
2023-09-25T08:43:03.7116402Z Prepare all required actions
2023-09-25T08:43:03.7307837Z Getting action download info
2023-09-25T08:43:03.9299380Z Download action repository 'actions/checkout@v4' (SHA:8ade135a41bc03ea155e62e844d188df1ea18608)
2023-09-25T08:43:04.2801669Z Download action repository 'actions/setup-node@v3' (SHA:5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d)
2023-09-25T08:43:04.7242356Z Complete job name: lint
2023-09-25T08:43:04.8215802Z ##[group]Run actions/checkout@v4
2023-09-25T08:43:04.8216412Z with:
2023-09-25T08:43:04.8216781Z   repository: jslawler/companiesdb
2023-09-25T08:43:04.8217407Z   token: ***
2023-09-25T08:43:04.8217701Z   ssh-strict: true
2023-09-25T08:43:04.8218077Z   persist-credentials: true
2023-09-25T08:43:04.8218490Z   clean: true
2023-09-25T08:43:04.8218812Z   sparse-checkout-cone-mode: true
2023-09-25T08:43:04.8219205Z   fetch-depth: 1
2023-09-25T08:43:04.8219560Z   fetch-tags: false
2023-09-25T08:43:04.8219856Z   show-progress: true
2023-09-25T08:43:04.8220259Z   lfs: false
2023-09-25T08:43:04.8220587Z   submodules: false
2023-09-25T08:43:04.8220906Z   set-safe-directory: true
2023-09-25T08:43:04.8221272Z ##[endgroup]
2023-09-25T08:43:05.0692197Z Syncing repository: jslawler/companiesdb
2023-09-25T08:43:05.0694322Z ##[group]Getting Git version info
2023-09-25T08:43:05.0694941Z Working directory is '/home/runner/work/companiesdb/companiesdb'
2023-09-25T08:43:05.0695864Z [command]/usr/bin/git version
2023-09-25T08:43:05.1005857Z git version 2.42.0
2023-09-25T08:43:05.1008560Z ##[endgroup]
2023-09-25T08:43:05.1024083Z Temporarily overriding HOME='/home/runner/work/_temp/5a1f345b-5ce1-4fea-999f-c46df83cd89d' before making global git config changes
2023-09-25T08:43:05.1024663Z Adding repository directory to the temporary git global config as a safe directory
2023-09-25T08:43:05.1039611Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/companiesdb/companiesdb
2023-09-25T08:43:05.1045119Z Deleting the contents of '/home/runner/work/companiesdb/companiesdb'
2023-09-25T08:43:05.1053688Z ##[group]Initializing the repository
2023-09-25T08:43:05.1057030Z [command]/usr/bin/git init /home/runner/work/companiesdb/companiesdb
2023-09-25T08:43:05.1125000Z hint: Using 'master' as the name for the initial branch. This default branch name
2023-09-25T08:43:05.1125999Z hint: is subject to change. To configure the initial branch name to use in all
2023-09-25T08:43:05.1126763Z hint: of your new repositories, which will suppress this warning, call:
2023-09-25T08:43:05.1127098Z hint: 
2023-09-25T08:43:05.1127559Z hint: 	git config --global init.defaultBranch <name>
2023-09-25T08:43:05.1127843Z hint: 
2023-09-25T08:43:05.1128241Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
2023-09-25T08:43:05.1128767Z hint: 'development'. The just-created branch can be renamed via this command:
2023-09-25T08:43:05.1129353Z hint: 
2023-09-25T08:43:05.1129633Z hint: 	git branch -m <name>
2023-09-25T08:43:05.1138451Z Initialized empty Git repository in /home/runner/work/companiesdb/companiesdb/.git/
2023-09-25T08:43:05.1151915Z [command]/usr/bin/git remote add origin https://github.com/jslawler/companiesdb
2023-09-25T08:43:05.1185638Z ##[endgroup]
2023-09-25T08:43:05.1186192Z ##[group]Disabling automatic garbage collection
2023-09-25T08:43:05.1191179Z [command]/usr/bin/git config --local gc.auto 0
2023-09-25T08:43:05.1219028Z ##[endgroup]
2023-09-25T08:43:05.1219513Z ##[group]Setting up auth
2023-09-25T08:43:05.1227297Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2023-09-25T08:43:05.1256970Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2023-09-25T08:43:05.1621827Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2023-09-25T08:43:05.1652096Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2023-09-25T08:43:05.1873954Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
2023-09-25T08:43:05.1927440Z ##[endgroup]
2023-09-25T08:43:05.1930808Z ##[group]Fetching the repository
2023-09-25T08:43:05.1943980Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +1813c2afda43dfa2e21c5e5859672ce7d24c7339:refs/remotes/origin/actions-test
2023-09-25T08:43:05.7124734Z From https://github.com/jslawler/companiesdb
2023-09-25T08:43:05.7125771Z  * [new ref]         1813c2afda43dfa2e21c5e5859672ce7d24c7339 -> origin/actions-test
2023-09-25T08:43:05.7153461Z ##[endgroup]
2023-09-25T08:43:05.7198560Z ##[group]Determining the checkout info
2023-09-25T08:43:05.7199221Z ##[endgroup]
2023-09-25T08:43:05.7199638Z ##[group]Checking out the ref
2023-09-25T08:43:05.7200262Z [command]/usr/bin/git checkout --progress --force -B actions-test refs/remotes/origin/actions-test
2023-09-25T08:43:05.7473018Z Switched to a new branch 'actions-test'
2023-09-25T08:43:05.7480396Z branch 'actions-test' set up to track 'origin/actions-test'.
2023-09-25T08:43:05.7482393Z ##[endgroup]
2023-09-25T08:43:05.7515017Z [command]/usr/bin/git log -1 --format='%H'
2023-09-25T08:43:05.7538960Z '1813c2afda43dfa2e21c5e5859672ce7d24c7339'
2023-09-25T08:43:05.8051805Z ##[group]Run actions/setup-node@v3
2023-09-25T08:43:05.8052080Z with:
2023-09-25T08:43:05.8052300Z   node-version: 18.x
2023-09-25T08:43:05.8052538Z   always-auth: false
2023-09-25T08:43:05.8052762Z   check-latest: false
2023-09-25T08:43:05.8053173Z   token: ***
2023-09-25T08:43:05.8053385Z ##[endgroup]
2023-09-25T08:43:06.1475248Z Found in cache @ /opt/hostedtoolcache/node/18.17.1/x64
2023-09-25T08:43:06.1488722Z ##[group]Environment details
2023-09-25T08:43:06.6651951Z node: v18.17.1
2023-09-25T08:43:06.6661865Z npm: 9.6.7
2023-09-25T08:43:06.6662604Z yarn: 1.22.19
2023-09-25T08:43:06.6663370Z ##[endgroup]
2023-09-25T08:43:06.6789371Z ##[group]Run yarn install
2023-09-25T08:43:06.6789710Z [36;1myarn install[0m
2023-09-25T08:43:06.6789932Z [36;1myarn lint[0m
2023-09-25T08:43:06.6854929Z shell: /usr/bin/bash -e {0}
2023-09-25T08:43:06.6855192Z ##[endgroup]
2023-09-25T08:43:06.8863256Z yarn install v1.22.19
2023-09-25T08:43:06.9465509Z [1/4] Resolving packages...
2023-09-25T08:43:07.0573055Z [2/4] Fetching packages...
2023-09-25T08:43:10.5713704Z [3/4] Linking dependencies...
2023-09-25T08:43:12.1273827Z [4/4] Building fresh packages...
2023-09-25T08:43:12.1356461Z Done in 5.26s.
2023-09-25T08:43:12.3541787Z yarn run v1.22.19
2023-09-25T08:43:12.3899702Z $ eslint .
2023-09-25T08:43:15.3527246Z Done in 3.00s.
2023-09-25T08:43:15.3709292Z Post job cleanup.
2023-09-25T08:43:15.5469879Z Post job cleanup.
2023-09-25T08:43:15.6400467Z [command]/usr/bin/git version
2023-09-25T08:43:15.6440052Z git version 2.42.0
2023-09-25T08:43:15.6488123Z Temporarily overriding HOME='/home/runner/work/_temp/03af4744-6edb-44eb-9882-bb2b3ecbd50f' before making global git config changes
2023-09-25T08:43:15.6488952Z Adding repository directory to the temporary git global config as a safe directory
2023-09-25T08:43:15.6493401Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/companiesdb/companiesdb
2023-09-25T08:43:15.6534634Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2023-09-25T08:43:15.6574780Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2023-09-25T08:43:15.6823662Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2023-09-25T08:43:15.6845934Z http.https://github.com/.extraheader
2023-09-25T08:43:15.6860284Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
2023-09-25T08:43:15.6892807Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2023-09-25T08:43:15.7461070Z Cleaning up orphan processes
```

</details>