### PR TITLE
Fix #267 Add tizenservice.com

### DIFF
--- a/source/trackers.json
+++ b/source/trackers.json
@@ -1581,6 +1581,7 @@
         "secmobilesvc.com": "samsungmobile",
         "internetat.tv": "samsungtv",
         "samsungcloud.tv": "samsungtv",
+        "tizenservice.com": "samsungtv",
         "samsungsds.com": "samsungsds",
         "push.samsungosp.com": "samsungpush",
         "pushmessage.samsung.com": "samsungpush",


### PR DESCRIPTION
tizenservice.com belongs to TizenOS, which is the OS used on Samsung TV's.