### PR TITLE
Add parent organisation for Let's Encrypt

### DIFF
--- a/source/companies.json
+++ b/source/companies.json
@@ -121,6 +121,11 @@
             "websiteUrl": "https://www.iqiyi.com/",
             "description": "iQiyi is a Chinese ad-supported television and movie portal providing fully-licensed, high-definition, professionally produced content"
         },
+        "isrg": {
+            "name": "Internet Security Research Group",
+            "websiteUrl": "https://www.abetterinternet.org",
+            "description": "Digital infrastructure for a more secure and privacy-respecting world."
+        },
         "karambasecurity": {
             "name": "Karamba Security",
             "websiteUrl": "https://karambasecurity.com/",
@@ -130,11 +135,6 @@
             "name": "Kik",
             "websiteUrl": "https://kik.com/",
             "description": "Kik Messenger, commonly called Kik, is a freeware instant messaging mobile app from the Canadian company Kik Interactive, available on iOS and Android operating systems."
-        },
-        "lets_encrypt": {
-            "name": "Let's Encrypt",
-            "websiteUrl": "https://letsencrypt.org/",
-            "description": "Let's Encrypt is a non-profit certificate authority run by Internet Security Research Group that provides X.509 certificates for Transport Layer Security encryption at no charge."
         },
         "lgcorp": {
             "name": "LG Group",

--- a/source/trackers.json
+++ b/source/trackers.json
@@ -462,7 +462,7 @@
             "name": "Let's Encrypt",
             "categoryId": 5,
             "url": "https://letsencrypt.org/",
-            "companyId": "lets_encrypt"
+            "companyId": "isrg"
         },
         "lgads": {
             "name": "LG Ad Solutions",


### PR DESCRIPTION
Let’s Encrypt is a free, automated, and open certificate authority (CA), run for the public’s benefit. It is a service provided by the [Internet Security Research Group (ISRG)](https://www.abetterinternet.org/).