### PR TITLE
add octocaptcha.com

### DIFF
--- a/source/trackers.json
+++ b/source/trackers.json
@@ -1206,6 +1206,7 @@
         "gameanalytics.com": "gameanalytics",
         "ghcr.io": "github",
         "github.dev": "github",
+        "octocaptcha.com": "github",
         "gmail.com": "gmail",
         "1e100.net": "google",
         "agnss.goog": "google",


### PR DESCRIPTION
Domain owned by GitHub.