### PR TITLE
Add digital turbine

### DIFF
--- a/source/companies.json
+++ b/source/companies.json
@@ -91,6 +91,11 @@
             "websiteUrl": "http://www.comodo.com/",
             "description": "Comodo is a global leader in cyber security solutions including antivirus, internet security, firewall, endpoint security, cloud based solutions and other PC security software for enterprises and consumers."
         },
+        "digital_turbine": {
+            "name": "Digital Turbine, Inc.",
+            "websiteUrl": "http://www.digitalturbine.com/",
+            "description": "Digital Turbine offers a one-stop platform for user acquisition growth and monetization."
+        },
         "disney": {
             "name": "The Walt Disney Company",
             "websiteUrl": "https://thewaltdisneycompany.com/",

--- a/source/trackers.json
+++ b/source/trackers.json
@@ -26,6 +26,12 @@
             "url": "https://www.abc.net.au/",
             "companyId": "australian_government"
         },
+        "adcolony": {
+            "name": "AdColony",
+            "categoryId": 4,
+            "url": "https://www.adcolony.com/history-of-adcolony/",
+            "companyId": "digital_turbine"
+        },
         "adguard": {
             "name": "AdGuard",
             "categoryId": 8,
@@ -1055,6 +1061,7 @@
         "abc.net.au": "abc",
         "abcaustralia.net.au": "abc",
         "abcradio.net.au": "abc",
+        "adcolony.com": "adcolony",
         "adguard.app": "adguard",
         "adguard.info": "adguard",
         "adguard.io": "adguard",


### PR DESCRIPTION
AdColony was purchased by Zynga, then by Digital Turbine. The domain added is still active and being used.