### PR TITLE
Add take two interactive software, inc 

### DIFF
--- a/source/companies.json
+++ b/source/companies.json
@@ -316,6 +316,11 @@
             "websiteUrl": "https://www.switch.tv/",
             "description": "Switch Media has successfully delivered complex, multi-award-winning online video solutions for major brands and global live streaming events."
         },
+        "take-two": {
+            "name": "Take-Two Interactive Software, Inc.",
+            "websiteUrl": "https://www.take2games.com/",
+            "description": "Take-Two Interactive Software, Inc. is an American video game holding company based in New York City founded by Ryan Brant in September 1993."
+        },
         "telstra": {
             "name": "Telstra",
             "websiteUrl": "https://www.telstra.com.au/",

--- a/source/trackers.json
+++ b/source/trackers.json
@@ -152,6 +152,12 @@
             "url": "https://canonical.com/",
             "companyId": "canonical"
         },
+        "chartboost": {
+            "name": "Chartboost",
+            "categoryId": 4,
+            "url": "http://chartboost.com/",
+            "companyId": "take-two"
+        },
         "crashlytics": {
             "name": "Crashlytics",
             "categoryId": 101,
@@ -1138,6 +1144,7 @@
         "mobileapptracking.com": "branch",
         "bttn.io": "button",
         "canonical.com": "canonical",
+        "chartboost.com": "chartboost.com",
         "cloudflare-dm-cmpimg.com": "cloudflare",
         "cloudflare-dns.com": "cloudflare",
         "cloudflare-ipfs.com": "cloudflare",

--- a/source/trackers.json
+++ b/source/trackers.json
@@ -1144,7 +1144,7 @@
         "mobileapptracking.com": "branch",
         "bttn.io": "button",
         "canonical.com": "canonical",
-        "chartboost.com": "chartboost.com",
+        "chartboost.com": "chartboost",
         "cloudflare-dm-cmpimg.com": "cloudflare",
         "cloudflare-dns.com": "cloudflare",
         "cloudflare-ipfs.com": "cloudflare",


### PR DESCRIPTION
Chartboost was purchased by take-two, is still active and used.