### PR TITLE
update tracker list: porn sites

### DIFF
--- a/source/trackers.json
+++ b/source/trackers.json
@@ -662,6 +662,12 @@
             "url": "https://www.plex.tv/",
             "companyId": "plex"
         },
+        "porntube": {
+            "name": "PornTube",
+            "categoryId": 3,
+            "url": "https://www.porntube.com/",
+            "companyId": null
+        },
         "qq.com": {
             "name": "QQ International",
             "categoryId": 2,
@@ -703,6 +709,12 @@
             "categoryId": 7,
             "url": "https://www.reddit.com",
             "companyId": "advance"
+        },
+        "redtube": {
+            "name": "redtube.com",
+            "categoryId": 3,
+            "url": "https://www.redtube.com",
+            "companyId": null
         },
         "samsung": {
             "name": "Samsung",
@@ -946,7 +958,7 @@
         },
         "xvideos_com": {
             "name": "Xvideos",
-            "categoryId": 8,
+            "categoryId": 3,
             "url": "https://www.xvideos.com",
             "companyId": "xvideos"
         },


### PR DESCRIPTION
Despite there is no category for "porn websites", it's more suitable to tag the websites with "pornversiting" category.

Split from https://github.com/AdguardTeam/AdGuardHome/pull/6453