### PR TITLE
add cloud.microsoft

### DIFF
--- a/source/trackers.json
+++ b/source/trackers.json
@@ -1681,6 +1681,7 @@
         "oppomobile.com": "oppo",
         "episerver.net": "optimizely",
         "oracleinfinity.io": "oracle_infinity",
+        "cloud.microsoft": "outlook",
         "hotmail.com": "outlook",
         "live.com": "outlook",
         "outlook.com": "outlook",


### PR DESCRIPTION
Domain belongs to Outlook on the web.
<img width="284" alt="Screenshot 2023-12-14 at 22 36 58" src="https://github.com/AdguardTeam/companiesdb/assets/149243371/873c2855-aee8-4856-8d11-b0c8e5261ee4">
