### PR TITLE
add svc.ms

### DIFF
--- a/source/trackers.json
+++ b/source/trackers.json
@@ -1684,6 +1684,7 @@
         "hotmail.com": "outlook",
         "live.com": "outlook",
         "outlook.com": "outlook",
+        "svc.ms": "outlook",
         "oztam.com.au": "oztam",
         "perfops.io": "perfops",
         "plex.bz": "plex",


### PR DESCRIPTION
Domain belongs to Outlook on the web.
<img width="348" alt="Screenshot 2023-12-14 at 22 42 10" src="https://github.com/AdguardTeam/companiesdb/assets/149243371/f1f518aa-4e35-4967-9021-5f65085a6622">
