### PR TITLE
add spo-msedge.net

### DIFF
--- a/source/trackers.json
+++ b/source/trackers.json
@@ -1640,6 +1640,7 @@
         "k-msedge.net": "msedge",
         "l-msedge.net": "msedge",
         "s-msedge.net": "msedge",
+        "spo-msedge.net": "msedge",
         "t-msedge.net": "msedge",
         "wac-msedge.net": "msedge",
         "nab.com": "nab",


### PR DESCRIPTION
Domain belongs to Microsoft Edge app.

<img width="282" alt="Screenshot 2023-12-14 at 22 47 36" src="https://github.com/AdguardTeam/companiesdb/assets/149243371/56ac3035-e228-475a-8087-3b75d7a890e8">
