### PR TITLE
add amap.com

### DIFF
--- a/source/trackers.json
+++ b/source/trackers.json
@@ -92,18 +92,6 @@
             "url": "https://about.ads.microsoft.com/en-us/solutions/xandr/xandr-premium-programmatic-advertising",
             "companyId": "microsoft"
         },
-        "appcenter": {
-            "name": "Microsoft App Center",
-            "categoryId": 5,
-            "url": "https://appcenter.ms/",
-            "companyId": "microsoft"
-        },
-        "appnexus": {
-            "name": "AppNexus",
-            "categoryId": 4,
-            "url": "https://about.ads.microsoft.com/en-us/solutions/xandr/xandr-premium-programmatic-advertising",
-            "companyId": "microsoft"
-        },
         "alibaba.com": {
             "name": "Alibaba",
             "categoryId": 8,
@@ -128,6 +116,18 @@
             "url": "https://global.alipay.com/",
             "companyId": "softbank"
         },
+        "amap": {
+            "name": "Amap",
+            "categoryId": 2,
+            "url": "https://www.amap.com/",
+            "companyId": "softbank"
+        },
+        "appcenter": {
+            "name": "Microsoft App Center",
+            "categoryId": 5,
+            "url": "https://appcenter.ms/",
+            "companyId": "microsoft"
+        },
         "apple": {
             "name": "Apple",
             "categoryId": 8,
@@ -139,6 +139,12 @@
             "categoryId": 4,
             "url": "https://searchads.apple.com/",
             "companyId": "apple"
+        },
+        "appnexus": {
+            "name": "AppNexus",
+            "categoryId": 4,
+            "url": "https://about.ads.microsoft.com/en-us/solutions/xandr/xandr-premium-programmatic-advertising",
+            "companyId": "microsoft"
         },
         "appsflyer": {
             "name": "AppsFlyer",
@@ -1173,6 +1179,7 @@
         "aliyun.com": "alibaba_cloud",
         "ucweb.com": "alibaba_ucbrowser",
         "alipayobjects.com": "alipay.com",
+        "amap.com": "amap",
         "a2z.com": "amazon",
         "aamazoncognito.com": "amazon",
         "amazon-corp.com": "amazon",


### PR DESCRIPTION
"Amap is a leading provider of digital map content, navigation, and location-based solutions in China. Established in 2002, Amap is now a wholly owned subsidiary of Alibaba Group and is integrated with the e-commerce ecosystem of Alibaba Group. In 2018, Amap became the first Chinese maps service to navigate a path to 100 million daily users."