### PR TITLE
Add agrd.eu

### DIFF
--- a/source/trackers.json
+++ b/source/trackers.json
@@ -1182,6 +1182,7 @@
         "adguard.org": "adguard",
         "adtidy.org": "adguard",
         "agrd.io": "adguard",
+        "agrd.eu": "adguard",
         "adguard-dns.com": "adguard_dns",
         "adguard-dns.io": "adguard_dns",
         "adguard-vpn.com": "adguard_vpn",


### PR DESCRIPTION
Service: AdGuard DNS
Sub-domain: [st.agrd.eu](url)

All records point to [1055008621.rsc.cdn77.org](url).
When visited, it shows it's connected to AdGuard.

> Code: NoSuchKey
> BucketName: adguard-websites-static
> RequestId: tx00000492549393940a719-00666a06a7-6271dc0-prg
> HostId: 6271dc0-prg-eu-1