### PR TITLE
add fastly-masque.net

### DIFF
--- a/source/trackers.json
+++ b/source/trackers.json
@@ -1322,6 +1322,7 @@
         "riot.im": "element",
         "graph.facebook.com": "facebook_audience",
         "farlightgames.com": "farlight_pte_ltd",
+        "fastly-masque.net": "fastly",
         "app-measurement.com": "firebase",
         "fcm.googleapis.com": "firebase",
         "firebase.com": "firebase",

--- a/source/trackers.json
+++ b/source/trackers.json
@@ -1322,7 +1322,7 @@
         "riot.im": "element",
         "graph.facebook.com": "facebook_audience",
         "farlightgames.com": "farlight_pte_ltd",
-        "fastly-masque.net": "fastly",
+        "fastly-masque.net": "fastlylb.net",
         "app-measurement.com": "firebase",
         "fcm.googleapis.com": "firebase",
         "firebase.com": "firebase",


### PR DESCRIPTION
Domain used for iCloud+ Private Relay queries, and Firefox secure DNS queries.

<img width="233" alt="Screenshot 2024-08-09 at 09 10 20" src="https://github.com/user-attachments/assets/6ab033a1-09eb-4cea-8064-b38ede88c160">

Refs
https://www.fastly.com/blog/icloud-private-relay-and-a-privacy-preserving-internet/
https://www.fastly.com/blog/firefox-fastly-take-another-step-toward-security-upgrade/