### PR TITLE
Add Proton Foundation, Proton AG, and reports.proton.me

### DIFF
--- a/source/companies.json
+++ b/source/companies.json
@@ -296,6 +296,11 @@
             "websiteUrl": "https://perfops.net/",
             "description": "Distributed infrastructure monitoring, smart traffic load-balancing and routing."
         },
+        "proton_foundation": {
+            "name": "Proton Foundation",
+            "websiteUrl": "https://proton.me/foundation/",
+            "description": "The Proton Foundation is a non-profit promoting privacy-focused, encrypted digital services like ProtonMail, advocating for internet privacy, security, and transparency worldwide."
+        },
         "qualcomm": {
             "name": "Qualcomm",
             "websiteUrl": "https://www.qualcomm.com/",

--- a/source/trackers.json
+++ b/source/trackers.json
@@ -746,6 +746,12 @@
             "url": "https://www.plex.tv/",
             "companyId": "plex"
         },
+        "proton_ag": {
+            "name": "Proton AG",
+            "categoryId": 2,
+            "url": "https://proton.me/",
+            "companyId": "proton_foundation"
+        },
         "qq.com": {
             "name": "QQ International",
             "categoryId": 2,
@@ -1773,6 +1779,7 @@
         "plex.bz": "plex",
         "plex.direct": "plex",
         "plex.tv": "plex",
+        "reports.proton.me": "proton_ag",
         "qualcomm.com": "qualcomm",
         "gpsonextra.net":"qualcomm_location_service",
         "izatcloud.net":"qualcomm_location_service",


### PR DESCRIPTION
This PR adds Proton Foundation as an owner company, Proton AG as a tracker owner, and the reports.proton.me domain, which is used for sending security, performance, reliability, and user analytics reports.