### PR TITLE
Remove phicdn.net from digicert

### DIFF
--- a/source/trackers.json
+++ b/source/trackers.json
@@ -1300,7 +1300,6 @@
         "sn-cloudflare.com": "cloudflare",
         "videodelivery.net": "cloudflare",
         "crashlytics.com": "crashlytics",
-        "phicdn.net": "digicert_trust_seal",
         "disneyplus.com": "disneyplus",
         "bamgrid.com": "disneystreaming",
         "dssedge.com": "disneystreaming",


### PR DESCRIPTION
Whois lookup shows no evidence that this is owned by Digicert as it's currently listed as.