### PR TITLE
add dual-s-msedge.net to list of trackers

### DIFF
--- a/source/trackers.json
+++ b/source/trackers.json
@@ -1710,6 +1710,7 @@
         "mozilla.org": "mozilla",
         "a-msedge.net": "msedge",
         "b-msedge.net": "msedge",
+        "dual-s-msedge.net": "msedge",
         "e-msedge.net": "msedge",
         "k-msedge.net": "msedge",
         "l-msedge.net": "msedge",


### PR DESCRIPTION
Domain identified when visiting outlook.office.com within the AdGuard DNS query logs.