### PR TITLE
add foxtelgroupcdn.net.au

### DIFF
--- a/source/trackers.json
+++ b/source/trackers.json
@@ -1364,6 +1364,7 @@
         "flurry.com": "flurry",
         "foxsports.com.au": "fox_sports",
         "foxtel.com.au": "foxtel",
+        "foxtelgroupcdn.net.au": "foxtel",
         "freeview.com": "freeview",
         "freeview.com.au": "freeview",
         "freeviewaustralia.tv": "freeview",


### PR DESCRIPTION
Request: vod-hevc-drm5-cf.foxtelgroupcdn.net.au
Service: AdGuard DNS
Product: Binge TV