### PR TITLE
Change icon domain from hbo.com to hbomax.com

### DIFF
--- a/source/vpn_services.json
+++ b/source/vpn_services.json
@@ -571,7 +571,7 @@
             "hbomax.com",
             "hbomaxcdn.com"
         ],
-        "icon_domain": "hbo.com"
+        "icon_domain": "hbomax.com"
     },
     {
         "service_id": "hulu",


### PR DESCRIPTION
Changed the HBO icon to the universal version because the current one was not clearly visible in dark theme.

**Before**
<img width="200" alt="IMG_0360" src="https://github.com/user-attachments/assets/77aa301b-7c58-416b-a846-d4559fae538f" />

**After**
<img width="44" height="48" alt="Diana_xg2w1" src="https://github.com/user-attachments/assets/933cb848-ff9e-4696-a2c3-574746949e21" />
